### PR TITLE
Fixed #2

### DIFF
--- a/src/bitExpert/Adrenaline/Responder/JsonResponder.php
+++ b/src/bitExpert/Adrenaline/Responder/JsonResponder.php
@@ -50,6 +50,9 @@ class JsonResponder implements Responder
             $response = $response->withHeader($header, $value);
         }
 
-        return $response->withStatus(200);
+        /** @var \bitExpert\Adrenaline\Domain\DomainPayload $payload */
+        $status = $payload->getStatus() ?: 200;
+
+        return $response->withStatus($status);
     }
 }

--- a/src/bitExpert/Adrenaline/Responder/TwigResponder.php
+++ b/src/bitExpert/Adrenaline/Responder/TwigResponder.php
@@ -92,6 +92,9 @@ class TwigResponder implements Responder
             $response = $response->withHeader($header, $value);
         }
 
-        return $response->withStatus(200);
+        /** @var \bitExpert\Adrenaline\Domain\DomainPayload $payload */
+        $status = $payload->getStatus() ?: 200;
+
+        return $response->withStatus($status);
     }
 }

--- a/tests/bitExpert/Adrenaline/Responder/JsonResponderUnitTest.php
+++ b/tests/bitExpert/Adrenaline/Responder/JsonResponderUnitTest.php
@@ -83,8 +83,35 @@ class JsonResponderUnitTest extends \PHPUnit_Framework_TestCase
         $domainPayload = new DomainPayload('test');
         $this->responder->setHeaders(['Content-Type' => 'my/type']);
         $responder = $this->responder;
+        /** @var ResponseInterface $response */
         $response = $responder($domainPayload, $this->response);
 
         $this->assertEquals(['application/json'], $response->getHeader('Content-Type'));
+    }
+
+    /**
+     * @test
+     */
+    public function respectsStatusCodeSetInPayload()
+    {
+        $domainPayload = (new DomainPayload('test'))->withStatus(400);
+        $responder = $this->responder;
+        /** @var ResponseInterface $response */
+        $response = $responder($domainPayload, $this->response);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function usesOkStatusCodeIfNoneSetInPayload()
+    {
+        $domainPayload = (new DomainPayload('test'));
+        $responder = $this->responder;
+        /** @var ResponseInterface $response */
+        $response = $responder($domainPayload, $this->response);
+
+        $this->assertEquals(200, $response->getStatusCode());
     }
 }

--- a/tests/bitExpert/Adrenaline/Responder/TwigResponderUnitTest.php
+++ b/tests/bitExpert/Adrenaline/Responder/TwigResponderUnitTest.php
@@ -131,4 +131,32 @@ class TwigResponderUnitTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(['text/html'], $response->getHeader('Content-Type'));
     }
+
+    /**
+     * @test
+     */
+    public function respectsStatusCodeSetInPayload()
+    {
+        $domainPayload = (new DomainPayload('test'))->withStatus(400);
+        $responder = $this->responder;
+        $responder->setTemplate('mytemplate.twig');
+        /** @var ResponseInterface $response */
+        $response = $responder($domainPayload, $this->response);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function usesOkStatusCodeIfNoneSetInPayload()
+    {
+        $domainPayload = (new DomainPayload('test'));
+        $responder = $this->responder;
+        $responder->setTemplate('mytemplate.twig');
+        /** @var ResponseInterface $response */
+        $response = $responder($domainPayload, $this->response);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
fixed JsonResponder to respect status code set in domainpayload
fixed TwigResponder to respect status code set in domainpayload
added unittests for fixes
fixes #2
