### PR TITLE
Added possibility to gather behaviors into plugins

### DIFF
--- a/src/bitExpert/Adrenaline/Plugin/Plugin.php
+++ b/src/bitExpert/Adrenaline/Plugin/Plugin.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the Adrenaline framework.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace bitExpert\Adrenaline\Plugin;
+
+use bitExpert\Adrenaline\Adrenaline;
+
+interface Plugin
+{
+    /**
+     * Attaches the plugin to the given instance of Adrenaline
+     *
+     * @param Adrenaline $adrenaline
+     * @return void
+     */
+    public function applyTo(Adrenaline $adrenaline);
+}

--- a/src/bitExpert/Adrenaline/Plugin/PluginBundle.php
+++ b/src/bitExpert/Adrenaline/Plugin/PluginBundle.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of the Adrenaline framework.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace bitExpert\Adrenaline\Plugin;
+
+interface PluginBundle extends Plugin
+{
+    /**
+     * Returns a new instance of the collection including the given plugin
+     * (immutable)
+     *
+     * @param Plugin $plugin
+     * @return PluginCollection
+     */
+    public function withPlugin(Plugin $plugin);
+}

--- a/src/bitExpert/Adrenaline/Plugin/SimplePluginBundle.php
+++ b/src/bitExpert/Adrenaline/Plugin/SimplePluginBundle.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of the Adrenaline framework.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace bitExpert\Adrenaline\Plugin;
+
+use bitExpert\Adrenaline\Adrenaline;
+use bitExpert\Slf4PsrLog\LoggerFactory;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Simple implementation of the {@link bitExpert\Adrenaline\Plugin\PluginCollection} interface
+ *
+ * @package bitExpert\Adrenaline\Plugin
+ */
+final class SimplePluginBundle implements PluginBundle
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var Plugin[]
+     */
+    private $plugins;
+
+    /**
+     * SimplePluginCollection constructor.
+     */
+    public function __construct()
+    {
+        $this->logger = LoggerFactory::getLogger(get_class($this));
+        $this->plugins = [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withPlugin(Plugin $plugin)
+    {
+        $instance = clone $this;
+        $instance->plugins[] = $plugin;
+        $this->logger->debug(sprintf(
+            'Added plugin "%s".',
+            get_class($plugin)
+        ));
+        return $instance;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function applyTo(Adrenaline $adrenaline)
+    {
+        foreach ($this->plugins as $plugin) {
+            $plugin->applyTo($adrenaline);
+
+            $this->logger->debug(sprintf(
+                'Applied plugin "%s".',
+                get_class($plugin)
+            ));
+        }
+    }
+}

--- a/tests/bitExpert/Adrenaline/AdrenalineUnitTest.php
+++ b/tests/bitExpert/Adrenaline/AdrenalineUnitTest.php
@@ -14,6 +14,7 @@ use bitExpert\Adrenaline\Action\Resolver\ActionResolverMiddleware;
 use bitExpert\Adrenaline\Helper\DeeplyInheritedRoute;
 use bitExpert\Adrenaline\Helper\InheritedRoute;
 use bitExpert\Adrenaline\Helper\TestMiddleware;
+use bitExpert\Adrenaline\Plugin\Plugin;
 use bitExpert\Adroit\Action\Executor\ActionExecutorMiddleware;
 use bitExpert\Adroit\Action\Resolver\ActionResolver;
 use bitExpert\Adroit\Responder\Executor\ResponderExecutorMiddleware;
@@ -562,5 +563,29 @@ class AdrenalineUnitTest extends \PHPUnit_Framework_TestCase
             }));
 
         return $router;
+    }
+
+    /**
+     * @test
+     */
+    public function pluginsGetAppliedWhenAttached()
+    {
+        $app = new Adrenaline([], [], null, $this->emitter);
+
+        $plugin = $this->getMock(Plugin::class);
+        $plugin2 = $this->getMock(Plugin::class);
+
+        $plugin->expects($this->once())
+            ->method('applyTo')
+            ->with($app);
+
+        $plugin2->expects($this->once())
+            ->method('applyTo')
+            ->with($app);
+
+        $app->attach($plugin);
+        $app->attach($plugin2);
+
+        $app($this->request, $this->response);
     }
 }

--- a/tests/bitExpert/Adrenaline/Plugin/SimplePluginBundleUnitTest.php
+++ b/tests/bitExpert/Adrenaline/Plugin/SimplePluginBundleUnitTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of the Adrenaline framework.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace bitExpert\Adrenaline\Plugin;
+
+use bitExpert\Adrenaline\Adrenaline;
+
+/**
+ * Unit test for {@link \bitExpert\Adrenaline\Plugin\SimplePluginBundle}.
+ */
+class SimplePluginBundleUnitTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function addingPluginIsImmutable()
+    {
+        $bundle = new SimplePluginBundle();
+        $bundle2 = $bundle->withPlugin($this->getMock(Plugin::class));
+
+        $this->assertNotSame($bundle, $bundle2);
+    }
+
+    /**
+     * @test
+     */
+    public function addedPluginWillBeApplied()
+    {
+        $adrenaline = $this->getMock(Adrenaline::class);
+        $bundle = new SimplePluginBundle();
+        $plugin = $this->getMock(Plugin::class);
+
+        $plugin->expects($this->once())
+            ->method('applyTo')
+            ->with($adrenaline);
+
+        $bundle = $bundle->withPlugin($plugin);
+        $bundle->applyTo($adrenaline);
+    }
+
+    /**
+     * @test
+     */
+    public function addedPluginsWillBeAppliedInCorrectOrder()
+    {
+        $expectedOrder = [
+            'plugin',
+            'plugin2'
+        ];
+
+        $givenOrder = [];
+
+        $adrenaline = $this->getMock(Adrenaline::class);
+        $bundle = new SimplePluginBundle();
+
+        $plugin = $this->getMock(Plugin::class);
+        $plugin2 = $this->getMock(Plugin::class);
+
+        $plugin->expects($this->once())
+            ->method('applyTo')
+            ->with($adrenaline)
+            ->will($this->returnCallback(function () use (&$givenOrder) {
+                $givenOrder[] = 'plugin';
+            }));
+
+        $plugin2->expects($this->once())
+            ->method('applyTo')
+            ->with($adrenaline)
+            ->will($this->returnCallback(function () use (&$givenOrder) {
+                $givenOrder[] = 'plugin2';
+            }));
+
+        $bundle = $bundle
+            ->withPlugin($plugin)
+            ->withPlugin($plugin2);
+
+        $bundle->applyTo($adrenaline);
+        $this->assertEquals($expectedOrder, $givenOrder);
+    }
+}


### PR DESCRIPTION
With this feature you may implement your own plugins and attach them to Adrenaline. This feature is helpful when you want to define a set of middlewares which should work together although they use different hooks of adrenaline. 

Simple example:

``` php
final class ActionExecutionTimeLoggerPlugin implements Plugin
{
    public function applyTo(Adrenaline $adrenaline) 
    {
        $adrenaline->beforeExecuteAction(function (ServerRequestInterface $request, ResponseInterface $response, callable $next = null)  {
            $request = $request->withAttribute(self::class, time()); 
            if ($next) {
                $response = $next($request, $response);
            }
            return $response;
        });

        $adrenaline->beforeResolveResponder(function (ServerRequestInterface $request, ResponseInterface $response, callable $next = null) use ($start) {
            $duration = time() - $request->getAttribute(self::class);
            // log the execution time
            if ($next) {
                $response = $next($request, $response);
            }
            return $response;
        });
    }
}

$adrenaline->attach(new ActionExecutionTimeLoggerPlugin());
```

Sure, this example is a very simple one but it demonstrates how cross-middleware functionalities may be bundled when one of the middlewares wouldn't make any sense standalone.
