### PR TITLE
Change in Travis config: Remove hhvm, add PHP 7.1 to build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: php
 matrix:
   include:
     - php: 7.0
-    - php: hhvm
-  allow_failures:
-    - php: hhvm
+    - php: 7.1
 
 before_script:
   - composer self-update


### PR DESCRIPTION
Since hhvm build can't run due to composer.json config limitations it does not make sense to run builds against it anyways. Instead let Travis run the build against PHP 7.0 and PHP 7.1.