### PR TITLE
Remove VersionEye badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 A PSR-7 micro framework built on top of the Adroit middleware to speed up your development ;)
 
 [![Build Status](https://travis-ci.org/bitExpert/adrenaline.svg?branch=master)](https://travis-ci.org/bitExpert/adrenaline)
-[![Dependency Status](https://www.versioneye.com/user/projects/57d9b3a71b70a70039625600/badge.svg?style=flat-square)](https://www.versioneye.com/user/projects/57d9b3a71b70a70039625600)
 [![Coverage Status](https://coveralls.io/repos/github/bitExpert/adrenaline/badge.svg?branch=master)](https://coveralls.io/github/bitExpert/adrenaline?branch=master)
 
 - [Getting started](#gettingstarted)


### PR DESCRIPTION
Remove the VersionEye badge from the readme file due to versioneye shutting down end of 2017.

More information about the VersionEye sunset process:
https://blog.versioneye.com/2017/10/19/versioneye-sunset-process/
